### PR TITLE
Replace Node.js backend with native Swift Roon protocol implementation

### DIFF
--- a/RoonController/RoonController.xcodeproj/project.pbxproj
+++ b/RoonController/RoonController.xcodeproj/project.pbxproj
@@ -8,19 +8,32 @@
 
 /* Begin PBXBuildFile section */
 		0206ACCC748F3AC269561DEE /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE5C81111DFF879D58805C8 /* SidebarView.swift */; };
+		13836A8383F8D63C9820E139 /* RoonStatusService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B42F23C3EEDF994180B2C8 /* RoonStatusService.swift */; };
+		2D6F1D2BB3A87F8C94B0CF53 /* RoonTransportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723F143D953CB6B15EF90372 /* RoonTransportService.swift */; };
+		2DE2B462A57FF4EF158CA59C /* RoonImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D0472C6296AD7408B6343BC /* RoonImageService.swift */; };
 		31D8FDDCB97A9EC2F22CCDF4 /* RoonModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F75FB3DE82DDCA6F017225C /* RoonModels.swift */; };
 		499F184FF6A98B535C8A0773 /* RoonColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89C612F323088B23891CBC08 /* RoonColors.swift */; };
 		519F92A185C861D59BAA94A4 /* PlayerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6208159EBB6F3E199BC08686 /* PlayerView.swift */; };
 		529A895FA3C4E32038B5FF81 /* RoonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C52F8ADAC395F6CAABFC56 /* RoonService.swift */; };
 		54911BE3A34F964675E4707E /* QueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926CDAEA0DDFB262E6BE81A /* QueueView.swift */; };
+		6D266F7B099DE5C6965D385F /* RoonRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBB7AF253E773CF41F680C9B /* RoonRegistration.swift */; };
 		83D2098070D56815105DD58C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1B2F25475F39979BA3F2E470 /* Assets.xcassets */; };
 		A1CC3BB098C5D1127AA08BB2 /* HistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4154732D9AD241A718F6DFE0 /* HistoryView.swift */; };
+		A274251364A81D4729548FC9 /* RoonConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66AFF8AEECA51078FB7A69F5 /* RoonConnection.swift */; };
+		A7599F91BDAC7698040C43B3 /* MOOMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6418DBE0BE5F34DA15279274 /* MOOMessage.swift */; };
+		A8A4A4D0C7408CC33789698E /* SOODDiscovery.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA398B7B0641731B7566DAC /* SOODDiscovery.swift */; };
 		A8A720BA6B2B39B2BE4319B2 /* RoonModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502C0AF9FE6B1E36CBBB5699 /* RoonModelsTests.swift */; };
+		AA9AD2B4FA8BAB22B099E117 /* RoonImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CADCC8E2D3C2CC720381FF5 /* RoonImageProvider.swift */; };
+		AB193BDF53C3C067242F4E81 /* LocalImageServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5068474C18A874A2DD981604 /* LocalImageServer.swift */; };
+		AFE37D0C73FD49F800B1BA35 /* default.profraw in Resources */ = {isa = PBXBuildFile; fileRef = 0DCD77DD76B502A0A3EEB770 /* default.profraw */; };
 		BA76D9EE334357CA73C2ED75 /* ConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 961DF94025297E364472E8E9 /* ConnectionView.swift */; };
 		C959637010EB96B877AB45F6 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCEE5B31B68C21920E308DD /* SettingsView.swift */; };
 		D163747CACBB2E3A080A0765 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E5A3B5B194123E7D9AE567 /* ContentView.swift */; };
+		D851EB9F920C997716B794FF /* MOOTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 307EC654890895E8FF7EC837 /* MOOTransport.swift */; };
 		DA3008D61AB3C948441093AE /* RoonServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED2B62A70A4641D8240F8444 /* RoonServiceTests.swift */; };
 		E3D11AF841A9512B0BBD7998 /* RoonControllerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 518520D9EE07BDDE1F23879A /* RoonControllerApp.swift */; };
+		F75452E0D6647FB2EF7B0ED1 /* RoonBrowseService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A217A313513ACF87512AA66A /* RoonBrowseService.swift */; };
+		FCCC73617CB748309BD3C119 /* RoonImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEBEFAB1D0DFC3EB7B52A76C /* RoonImageCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,20 +48,33 @@
 
 /* Begin PBXFileReference section */
 		0BFD1EE34B068DB0496A9F51 /* RoonControllerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RoonControllerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DCD77DD76B502A0A3EEB770 /* default.profraw */ = {isa = PBXFileReference; path = default.profraw; sourceTree = "<group>"; };
 		13E5A3B5B194123E7D9AE567 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1B2F25475F39979BA3F2E470 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		307EC654890895E8FF7EC837 /* MOOTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOOTransport.swift; sourceTree = "<group>"; };
 		4154732D9AD241A718F6DFE0 /* HistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryView.swift; sourceTree = "<group>"; };
 		47815C3C2FB6ED9B1402F795 /* RoonController.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RoonController.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4926CDAEA0DDFB262E6BE81A /* QueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueView.swift; sourceTree = "<group>"; };
 		4FCEE5B31B68C21920E308DD /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		502C0AF9FE6B1E36CBBB5699 /* RoonModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonModelsTests.swift; sourceTree = "<group>"; };
+		5068474C18A874A2DD981604 /* LocalImageServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalImageServer.swift; sourceTree = "<group>"; };
 		518520D9EE07BDDE1F23879A /* RoonControllerApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonControllerApp.swift; sourceTree = "<group>"; };
 		6208159EBB6F3E199BC08686 /* PlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerView.swift; sourceTree = "<group>"; };
+		6418DBE0BE5F34DA15279274 /* MOOMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MOOMessage.swift; sourceTree = "<group>"; };
+		66AFF8AEECA51078FB7A69F5 /* RoonConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonConnection.swift; sourceTree = "<group>"; };
 		6F75FB3DE82DDCA6F017225C /* RoonModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonModels.swift; sourceTree = "<group>"; };
+		723F143D953CB6B15EF90372 /* RoonTransportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonTransportService.swift; sourceTree = "<group>"; };
 		89C612F323088B23891CBC08 /* RoonColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonColors.swift; sourceTree = "<group>"; };
 		92A3271B5BF5E27D48F206C8 /* RoonController.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = RoonController.entitlements; sourceTree = "<group>"; };
 		961DF94025297E364472E8E9 /* ConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionView.swift; sourceTree = "<group>"; };
+		9CADCC8E2D3C2CC720381FF5 /* RoonImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonImageProvider.swift; sourceTree = "<group>"; };
+		9D0472C6296AD7408B6343BC /* RoonImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonImageService.swift; sourceTree = "<group>"; };
+		A217A313513ACF87512AA66A /* RoonBrowseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonBrowseService.swift; sourceTree = "<group>"; };
+		A3B42F23C3EEDF994180B2C8 /* RoonStatusService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonStatusService.swift; sourceTree = "<group>"; };
 		A5C52F8ADAC395F6CAABFC56 /* RoonService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonService.swift; sourceTree = "<group>"; };
+		ACA398B7B0641731B7566DAC /* SOODDiscovery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SOODDiscovery.swift; sourceTree = "<group>"; };
+		AEBEFAB1D0DFC3EB7B52A76C /* RoonImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonImageCache.swift; sourceTree = "<group>"; };
+		BBB7AF253E773CF41F680C9B /* RoonRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonRegistration.swift; sourceTree = "<group>"; };
 		ED2B62A70A4641D8240F8444 /* RoonServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoonServiceTests.swift; sourceTree = "<group>"; };
 		EEE5C81111DFF879D58805C8 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -61,6 +87,15 @@
 				ED2B62A70A4641D8240F8444 /* RoonServiceTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		4F8E7AF54E07D28960063306 /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				66AFF8AEECA51078FB7A69F5 /* RoonConnection.swift */,
+				BBB7AF253E773CF41F680C9B /* RoonRegistration.swift */,
+			);
+			path = Core;
 			sourceTree = "<group>";
 		};
 		57CF163E76FF13B0523B2653 /* Helpers */ = {
@@ -90,8 +125,40 @@
 			isa = PBXGroup;
 			children = (
 				A5C52F8ADAC395F6CAABFC56 /* RoonService.swift */,
+				BAA42F1B92C46E0DC726CF80 /* Roon */,
 			);
 			path = Services;
+			sourceTree = "<group>";
+		};
+		6A96050681478CF9C7615F52 /* Image */ = {
+			isa = PBXGroup;
+			children = (
+				5068474C18A874A2DD981604 /* LocalImageServer.swift */,
+				AEBEFAB1D0DFC3EB7B52A76C /* RoonImageCache.swift */,
+				9CADCC8E2D3C2CC720381FF5 /* RoonImageProvider.swift */,
+			);
+			path = Image;
+			sourceTree = "<group>";
+		};
+		AB477E722A7BBD917D443194 /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				6418DBE0BE5F34DA15279274 /* MOOMessage.swift */,
+				307EC654890895E8FF7EC837 /* MOOTransport.swift */,
+				ACA398B7B0641731B7566DAC /* SOODDiscovery.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
+		BAA42F1B92C46E0DC726CF80 /* Roon */ = {
+			isa = PBXGroup;
+			children = (
+				4F8E7AF54E07D28960063306 /* Core */,
+				6A96050681478CF9C7615F52 /* Image */,
+				AB477E722A7BBD917D443194 /* Protocol */,
+				D0DC84B00828A4BE290D055E /* Services */,
+			);
+			path = Roon;
 			sourceTree = "<group>";
 		};
 		C386E6C9C18E39CC8E474385 /* Models */ = {
@@ -106,6 +173,7 @@
 			isa = PBXGroup;
 			children = (
 				1B2F25475F39979BA3F2E470 /* Assets.xcassets */,
+				0DCD77DD76B502A0A3EEB770 /* default.profraw */,
 				92A3271B5BF5E27D48F206C8 /* RoonController.entitlements */,
 				518520D9EE07BDDE1F23879A /* RoonControllerApp.swift */,
 				C386E6C9C18E39CC8E474385 /* Models */,
@@ -114,6 +182,17 @@
 			);
 			name = RoonController;
 			path = .;
+			sourceTree = "<group>";
+		};
+		D0DC84B00828A4BE290D055E /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				A217A313513ACF87512AA66A /* RoonBrowseService.swift */,
+				9D0472C6296AD7408B6343BC /* RoonImageService.swift */,
+				A3B42F23C3EEDF994180B2C8 /* RoonStatusService.swift */,
+				723F143D953CB6B15EF90372 /* RoonTransportService.swift */,
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 		D1876C3791EAAF794DAB00BA = {
@@ -216,6 +295,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				83D2098070D56815105DD58C /* Assets.xcassets in Resources */,
+				AFE37D0C73FD49F800B1BA35 /* default.profraw in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -238,12 +318,24 @@
 				BA76D9EE334357CA73C2ED75 /* ConnectionView.swift in Sources */,
 				D163747CACBB2E3A080A0765 /* ContentView.swift in Sources */,
 				A1CC3BB098C5D1127AA08BB2 /* HistoryView.swift in Sources */,
+				AB193BDF53C3C067242F4E81 /* LocalImageServer.swift in Sources */,
+				A7599F91BDAC7698040C43B3 /* MOOMessage.swift in Sources */,
+				D851EB9F920C997716B794FF /* MOOTransport.swift in Sources */,
 				519F92A185C861D59BAA94A4 /* PlayerView.swift in Sources */,
 				54911BE3A34F964675E4707E /* QueueView.swift in Sources */,
+				F75452E0D6647FB2EF7B0ED1 /* RoonBrowseService.swift in Sources */,
 				499F184FF6A98B535C8A0773 /* RoonColors.swift in Sources */,
+				A274251364A81D4729548FC9 /* RoonConnection.swift in Sources */,
 				E3D11AF841A9512B0BBD7998 /* RoonControllerApp.swift in Sources */,
+				FCCC73617CB748309BD3C119 /* RoonImageCache.swift in Sources */,
+				AA9AD2B4FA8BAB22B099E117 /* RoonImageProvider.swift in Sources */,
+				2DE2B462A57FF4EF158CA59C /* RoonImageService.swift in Sources */,
 				31D8FDDCB97A9EC2F22CCDF4 /* RoonModels.swift in Sources */,
+				6D266F7B099DE5C6965D385F /* RoonRegistration.swift in Sources */,
 				529A895FA3C4E32038B5FF81 /* RoonService.swift in Sources */,
+				13836A8383F8D63C9820E139 /* RoonStatusService.swift in Sources */,
+				2D6F1D2BB3A87F8C94B0CF53 /* RoonTransportService.swift in Sources */,
+				A8A4A4D0C7408CC33789698E /* SOODDiscovery.swift in Sources */,
 				C959637010EB96B877AB45F6 /* SettingsView.swift in Sources */,
 				0206ACCC748F3AC269561DEE /* SidebarView.swift in Sources */,
 			);

--- a/RoonController/RoonControllerApp.swift
+++ b/RoonController/RoonControllerApp.swift
@@ -12,7 +12,6 @@ struct RoonControllerApp: App {
                 .preferredColorScheme(.dark)
                 .tint(Color.roonAccent)
                 .task {
-                    await roonService.ensureBackendRunning()
                     roonService.connect()
                 }
         }

--- a/RoonController/Services/Roon/Core/RoonConnection.swift
+++ b/RoonController/Services/Roon/Core/RoonConnection.swift
@@ -1,0 +1,421 @@
+import Foundation
+
+// MARK: - Roon Connection Orchestrator
+
+/// Orchestrates the full lifecycle of a connection to Roon Core:
+/// SOOD discovery → WebSocket connect → MOO registration → message routing.
+/// Handles bidirectional communication (extension sends requests, Core sends requests back).
+actor RoonConnection {
+
+    // MARK: - State
+
+    enum ConnectionState: Sendable {
+        case disconnected
+        case discovering
+        case connecting
+        case registering
+        case connected(coreName: String)
+        case failed(String)
+    }
+
+    private(set) var state: ConnectionState = .disconnected
+
+    // MARK: - Callbacks (use Data to stay Sendable)
+
+    var onStateChange: (@Sendable (ConnectionState) -> Void)?
+    var onZonesData: (@Sendable (Data) -> Void)?
+    var onQueueData: (@Sendable (String, Data) -> Void)?
+
+    // MARK: - Components
+
+    private let transport = MOOTransport()
+    private let discovery = SOODDiscovery()
+    private let requestIds = MOORequestIdGenerator()
+
+    // MARK: - Pending requests (for async request/response)
+
+    private var pendingRequests: [Int: CheckedContinuation<MOOMessage, Error>] = [:]
+
+    // MARK: - Subscriptions
+
+    private var zoneSubscriptionRequestId: Int?
+    private var queueSubscriptions: [String: Int] = [:] // zone_id -> requestId
+
+    // MARK: - Core info
+
+    private(set) var coreHost: String?
+    private(set) var corePort: Int?
+    private(set) var coreName: String?
+
+    // MARK: - Service names (assigned by Core during registration)
+
+    private(set) var transportServiceName: String?
+    private(set) var browseServiceName: String?
+    private(set) var imageServiceName: String?
+
+    // MARK: - Reconnection
+
+    private var reconnectTask: Task<Void, Never>?
+    private var reconnectAttempt = 0
+    private let maxReconnectDelay: Double = 30
+    private var shouldReconnect = false
+
+    // MARK: - Connect
+
+    func connect() async {
+        shouldReconnect = true
+        reconnectAttempt = 0
+        updateState(.discovering)
+        await startDiscovery()
+    }
+
+    func connectDirect(host: String, port: Int = 9330) async {
+        shouldReconnect = true
+        reconnectAttempt = 0
+        coreHost = host
+        corePort = port
+        await connectToCore(host: host, port: port)
+    }
+
+    func disconnect() async {
+        shouldReconnect = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        await discovery.stop()
+        await transport.disconnect()
+        pendingRequests.values.forEach { $0.resume(throwing: MOOTransportError.notConnected) }
+        pendingRequests.removeAll()
+        zoneSubscriptionRequestId = nil
+        queueSubscriptions.removeAll()
+        updateState(.disconnected)
+    }
+
+    // MARK: - Discovery
+
+    private func startDiscovery() async {
+        await discovery.stop()
+
+        await discovery.setOnCoreDiscovered { [weak self] core in
+            Task { [weak self] in
+                guard let self = self else { return }
+                let currentState = await self.state
+                if case .discovering = currentState {
+                    await self.discovery.stop()
+                    await self.connectToCore(host: core.host, port: core.port)
+                }
+            }
+        }
+
+        await discovery.start()
+    }
+
+    // MARK: - Core Connection
+
+    private func connectToCore(host: String, port: Int) async {
+        coreHost = host
+        corePort = port
+        updateState(.connecting)
+
+        await transport.setOnMessage { [weak self] message in
+            Task { [weak self] in
+                await self?.handleMessage(message)
+            }
+        }
+
+        await transport.setOnStateChange { [weak self] transportState in
+            Task { [weak self] in
+                if case .disconnected = transportState {
+                    await self?.handleTransportDisconnect()
+                }
+            }
+        }
+
+        await transport.connect(host: host, port: port)
+        await performRegistration()
+    }
+
+    // MARK: - Registration Handshake
+
+    private func performRegistration() async {
+        updateState(.registering)
+
+        do {
+            // Step 1: Send registry:1/info
+            let infoBody = try JSONSerialization.data(withJSONObject: RoonRegistration.infoRequestBody())
+            let infoResponse = try await sendRequestData(
+                name: "com.roonlabs.registry:1/info",
+                bodyData: infoBody
+            )
+
+            if let body = infoResponse.bodyJSON {
+                parseServiceNames(from: body)
+            }
+
+            // Step 2: Send registry:1/register
+            let registerBody = try JSONSerialization.data(withJSONObject: RoonRegistration.registerRequestBody())
+            let registerResponse = try await sendRequestData(
+                name: "com.roonlabs.registry:1/register",
+                bodyData: registerBody
+            )
+
+            let result = RoonRegistration.parseRegistrationResponse(registerResponse.bodyJSON)
+            switch result {
+            case .registered(let token, let coreId, let name):
+                RoonRegistration.saveToken(token, coreId: coreId)
+                coreName = name.isEmpty ? "Roon Core" : name
+                reconnectAttempt = 0
+                updateState(.connected(coreName: coreName ?? "Roon Core"))
+                await subscribeZones()
+
+            case .notRegistered:
+                break
+            }
+        } catch {
+            updateState(.failed("Registration failed: \(error.localizedDescription)"))
+            scheduleReconnect()
+        }
+    }
+
+    // MARK: - Message Routing
+
+    private func handleMessage(_ message: MOOMessage) {
+        switch message.verb {
+        case .complete, .continue:
+            handleResponse(message)
+        case .request:
+            handleCoreRequest(message)
+        }
+    }
+
+    private func handleResponse(_ message: MOOMessage) {
+        let requestId = message.requestId
+
+        if message.verb == .continue {
+            if requestId == zoneSubscriptionRequestId {
+                handleZoneSubscriptionUpdate(message)
+                return
+            }
+            if let zoneId = queueSubscriptions.first(where: { $0.value == requestId })?.key {
+                handleQueueSubscriptionUpdate(message, zoneId: zoneId)
+                return
+            }
+            // Could be a delayed registration response
+            if message.name.contains("register") || message.name == "Registered" {
+                let result = RoonRegistration.parseRegistrationResponse(message.bodyJSON)
+                if case .registered(let token, let coreId, let name) = result {
+                    RoonRegistration.saveToken(token, coreId: coreId)
+                    coreName = name.isEmpty ? "Roon Core" : name
+                    updateState(.connected(coreName: coreName ?? "Roon Core"))
+                    Task { await self.subscribeZones() }
+                }
+                return
+            }
+        }
+
+        if let continuation = pendingRequests.removeValue(forKey: requestId) {
+            continuation.resume(returning: message)
+        }
+    }
+
+    private func handleCoreRequest(_ message: MOOMessage) {
+        let name = message.name
+
+        if name.hasSuffix("/ping") || name.contains("ping:1") {
+            let response = MOOMessage.complete(name: "Success", requestId: message.requestId)
+            Task { try? await transport.send(response) }
+        } else if name.contains("status:1") || name.hasSuffix("/subscribe_status") {
+            let statusBody: [String: Any] = ["message": "Ready", "is_error": false]
+            if let jsonData = try? JSONSerialization.data(withJSONObject: statusBody) {
+                let response = MOOMessage.complete(name: "Subscribed", requestId: message.requestId, body: jsonData)
+                Task { try? await transport.send(response) }
+            }
+        }
+    }
+
+    // MARK: - Zone Subscription
+
+    private func subscribeZones() async {
+        let requestId = requestIds.next()
+        zoneSubscriptionRequestId = requestId
+
+        let body: [String: Any] = ["subscription_key": "zones"]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
+
+        let data = MOOMessage.request(
+            name: "\(transportServiceName ?? "com.roonlabs.transport:2")/subscribe_zones",
+            requestId: requestId,
+            body: bodyData
+        )
+        try? await transport.send(data)
+    }
+
+    private func handleZoneSubscriptionUpdate(_ message: MOOMessage) {
+        guard let body = message.body else { return }
+        onZonesData?(body)
+    }
+
+    // MARK: - Queue Subscription
+
+    func subscribeQueue(zoneId: String) async {
+        queueSubscriptions.removeValue(forKey: zoneId)
+
+        let requestId = requestIds.next()
+        queueSubscriptions[zoneId] = requestId
+
+        let body: [String: Any] = [
+            "subscription_key": "queue_\(zoneId)",
+            "max_items": 100
+        ]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return }
+
+        let data = MOOMessage.request(
+            name: "\(transportServiceName ?? "com.roonlabs.transport:2")/subscribe_queue",
+            requestId: requestId,
+            body: bodyData
+        )
+        try? await transport.send(data)
+    }
+
+    private func handleQueueSubscriptionUpdate(_ message: MOOMessage, zoneId: String) {
+        guard let body = message.body else { return }
+        onQueueData?(zoneId, body)
+    }
+
+    // MARK: - Public Request API
+
+    /// Send a MOO request with pre-serialized body data and wait for the response.
+    func sendRequestData(name: String, bodyData: Data? = nil) async throws -> MOOMessage {
+        let requestId = requestIds.next()
+
+        let data: Data
+        if let bodyData = bodyData {
+            data = MOOMessage.request(name: name, requestId: requestId, body: bodyData)
+        } else {
+            data = MOOMessage.request(name: name, requestId: requestId)
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingRequests[requestId] = continuation
+
+            Task {
+                do {
+                    try await transport.send(data)
+                } catch {
+                    if let cont = pendingRequests.removeValue(forKey: requestId) {
+                        cont.resume(throwing: error)
+                    }
+                }
+            }
+
+            Task {
+                try? await Task.sleep(nanoseconds: 30_000_000_000)
+                if let cont = pendingRequests.removeValue(forKey: requestId) {
+                    cont.resume(throwing: MOOTransportError.timeout)
+                }
+            }
+        }
+    }
+
+    // MARK: - Service Name Helpers
+
+    func transportService() -> String {
+        transportServiceName ?? "com.roonlabs.transport:2"
+    }
+
+    func browseService() -> String {
+        browseServiceName ?? "com.roonlabs.browse:1"
+    }
+
+    func imageService() -> String {
+        imageServiceName ?? "com.roonlabs.image:1"
+    }
+
+    // MARK: - Private Helpers
+
+    private func parseServiceNames(from body: [String: Any]) {
+        if let services = body["services"] as? [[String: Any]] {
+            for service in services {
+                guard let name = service["name"] as? String else { continue }
+                if name.contains("transport") {
+                    transportServiceName = name
+                } else if name.contains("browse") {
+                    browseServiceName = name
+                } else if name.contains("image") {
+                    imageServiceName = name
+                }
+            }
+        }
+    }
+
+    private func handleTransportDisconnect() {
+        let wasConnected: Bool
+        if case .connected = state { wasConnected = true } else { wasConnected = false }
+
+        pendingRequests.values.forEach { $0.resume(throwing: MOOTransportError.notConnected) }
+        pendingRequests.removeAll()
+        zoneSubscriptionRequestId = nil
+        queueSubscriptions.removeAll()
+
+        updateState(.disconnected)
+
+        if wasConnected && shouldReconnect {
+            scheduleReconnect()
+        }
+    }
+
+    private func scheduleReconnect() {
+        guard shouldReconnect else { return }
+        reconnectTask?.cancel()
+
+        let delay = min(pow(2.0, Double(reconnectAttempt)), maxReconnectDelay)
+        reconnectAttempt += 1
+
+        reconnectTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            guard let self = self else { return }
+            let host = await self.coreHost
+            let port = await self.corePort
+
+            if let host = host, let port = port {
+                await self.connectToCore(host: host, port: port)
+            } else {
+                await self.connect()
+            }
+        }
+    }
+
+    private func updateState(_ newState: ConnectionState) {
+        state = newState
+        onStateChange?(newState)
+    }
+}
+
+// MARK: - Actor helper extensions
+
+extension RoonConnection {
+    func setOnStateChange(_ handler: @escaping @Sendable (ConnectionState) -> Void) {
+        onStateChange = handler
+    }
+    func setOnZonesData(_ handler: @escaping @Sendable (Data) -> Void) {
+        onZonesData = handler
+    }
+    func setOnQueueData(_ handler: @escaping @Sendable (String, Data) -> Void) {
+        onQueueData = handler
+    }
+}
+
+extension SOODDiscovery {
+    func setOnCoreDiscovered(_ handler: @escaping @Sendable (DiscoveredCore) -> Void) {
+        onCoreDiscovered = handler
+    }
+}
+
+extension MOOTransport {
+    func setOnMessage(_ handler: @escaping @Sendable (MOOMessage) -> Void) {
+        onMessage = handler
+    }
+    func setOnStateChange(_ handler: @escaping @Sendable (State) -> Void) {
+        onStateChange = handler
+    }
+}

--- a/RoonController/Services/Roon/Core/RoonRegistration.swift
+++ b/RoonController/Services/Roon/Core/RoonRegistration.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+// MARK: - Roon Registration
+
+/// Handles the Roon extension registration handshake and token persistence.
+/// The handshake flow:
+/// 1. Send `registry:1/info` → receive Core info
+/// 2. Send `registry:1/register` with extension info + optional saved token
+/// 3. Receive `Registered` with token to persist, or `NotRegistered`
+struct RoonRegistration {
+
+    // MARK: - Extension Info
+
+    static let extensionId = "com.bertrand.rooncontroller"
+    static let displayName = "Roon Controller macOS"
+    static let displayVersion = "1.0.0"
+    static let publisher = "Bertrand"
+    static let email = ""
+
+    // MARK: - Token Persistence
+
+    private static let tokenKey = "roon_core_token"
+    private static let pairedCoreIdKey = "roon_paired_core_id"
+
+    static func savedToken() -> String? {
+        UserDefaults.standard.string(forKey: tokenKey)
+    }
+
+    static func saveToken(_ token: String, coreId: String? = nil) {
+        UserDefaults.standard.set(token, forKey: tokenKey)
+        if let coreId = coreId {
+            UserDefaults.standard.set(coreId, forKey: pairedCoreIdKey)
+        }
+    }
+
+    static func clearToken() {
+        UserDefaults.standard.removeObject(forKey: tokenKey)
+        UserDefaults.standard.removeObject(forKey: pairedCoreIdKey)
+    }
+
+    static func savedCoreId() -> String? {
+        UserDefaults.standard.string(forKey: pairedCoreIdKey)
+    }
+
+    // MARK: - Registration Payloads
+
+    /// Build the `registry:1/info` request body.
+    static func infoRequestBody() -> [String: Any] {
+        [:]
+    }
+
+    /// Build the `registry:1/register` request body.
+    static func registerRequestBody() -> [String: Any] {
+        var body: [String: Any] = [
+            "extension_id": extensionId,
+            "display_name": displayName,
+            "display_version": displayVersion,
+            "publisher": publisher,
+            "email": email,
+            "required_services": [
+                ["name": "com.roonlabs.transport:2"],
+                ["name": "com.roonlabs.browse:1"],
+                ["name": "com.roonlabs.image:1"]
+            ],
+            "provided_services": [
+                ["name": "com.roonlabs.ping:1"],
+                ["name": "com.roonlabs.status:1"]
+            ],
+            "website": ""
+        ]
+
+        if let token = savedToken() {
+            body["token"] = token
+        }
+
+        return body
+    }
+
+    // MARK: - Response Handling
+
+    enum RegistrationResult {
+        case registered(token: String, coreId: String, coreName: String)
+        case notRegistered
+    }
+
+    /// Parse a registration response from the Core.
+    static func parseRegistrationResponse(_ body: [String: Any]?) -> RegistrationResult {
+        guard let body = body else { return .notRegistered }
+
+        if let token = body["token"] as? String {
+            let coreId = body["core_id"] as? String ?? ""
+            let coreName = body["display_name"] as? String ?? ""
+            return .registered(token: token, coreId: coreId, coreName: coreName)
+        }
+
+        return .notRegistered
+    }
+
+    /// Build the status message body for provided status service.
+    static func statusBody(message: String = "Ready", isError: Bool = false) -> [String: Any] {
+        [
+            "message": message,
+            "is_error": isError
+        ]
+    }
+}

--- a/RoonController/Services/Roon/Image/LocalImageServer.swift
+++ b/RoonController/Services/Roon/Image/LocalImageServer.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Network
+
+// MARK: - Local Image Server
+
+/// Minimal HTTP server on localhost:9150 that serves Roon images to SwiftUI AsyncImage views.
+/// URL format: `http://localhost:9150/image/{key}?width=N&height=N`
+/// This avoids modifying any views that use AsyncImage(url:).
+actor LocalImageServer {
+
+    static let shared = LocalImageServer()
+    static let port: UInt16 = 9150
+
+    private var listener: NWListener?
+    private var isRunning = false
+
+    // MARK: - Start / Stop
+
+    func start() {
+        guard !isRunning else { return }
+
+        let params = NWParameters.tcp
+        params.allowLocalEndpointReuse = true
+
+        do {
+            let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: Self.port)!)
+            self.listener = listener
+
+            listener.stateUpdateHandler = { [weak self] state in
+                switch state {
+                case .ready:
+                    Task { await self?.setRunning(true) }
+                case .failed:
+                    Task { await self?.restart() }
+                default:
+                    break
+                }
+            }
+
+            listener.newConnectionHandler = { [weak self] connection in
+                Task { await self?.handleConnection(connection) }
+            }
+
+            listener.start(queue: .global(qos: .utility))
+        } catch {
+            // Failed to start listener
+        }
+    }
+
+    func stop() {
+        listener?.cancel()
+        listener = nil
+        isRunning = false
+    }
+
+    private func setRunning(_ value: Bool) {
+        isRunning = value
+    }
+
+    private func restart() {
+        stop()
+        start()
+    }
+
+    // MARK: - URL Generation
+
+    /// Generate a URL for an image served by this local server.
+    nonisolated static func imageURL(key: String, width: Int = 300, height: Int = 300) -> URL? {
+        URL(string: "http://localhost:\(port)/image/\(key)?width=\(width)&height=\(height)")
+    }
+
+    // MARK: - Connection Handling
+
+    private nonisolated func handleConnection(_ connection: NWConnection) {
+        connection.start(queue: .global(qos: .utility))
+
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 8192) { data, _, _, error in
+            guard let data = data, error == nil else {
+                connection.cancel()
+                return
+            }
+
+            guard let request = String(data: data, encoding: .utf8) else {
+                Self.sendResponse(connection: connection, status: 400, body: Data("Bad Request".utf8))
+                return
+            }
+
+            Task {
+                await Self.handleHTTPRequest(request, connection: connection)
+            }
+        }
+    }
+
+    // MARK: - HTTP Request Parsing
+
+    private static func handleHTTPRequest(_ request: String, connection: NWConnection) async {
+        // Parse: GET /image/{key}?width=N&height=N HTTP/1.1
+        let lines = request.components(separatedBy: "\r\n")
+        guard let requestLine = lines.first else {
+            sendResponse(connection: connection, status: 400, body: Data("Bad Request".utf8))
+            return
+        }
+
+        let parts = requestLine.split(separator: " ")
+        guard parts.count >= 2, parts[0] == "GET" else {
+            sendResponse(connection: connection, status: 405, body: Data("Method Not Allowed".utf8))
+            return
+        }
+
+        let pathAndQuery = String(parts[1])
+        guard pathAndQuery.hasPrefix("/image/") else {
+            sendResponse(connection: connection, status: 404, body: Data("Not Found".utf8))
+            return
+        }
+
+        // Extract key and query params
+        let pathWithoutPrefix = String(pathAndQuery.dropFirst("/image/".count))
+        let components = pathWithoutPrefix.split(separator: "?", maxSplits: 1)
+        let key = String(components[0])
+
+        var width = 300
+        var height = 300
+
+        if components.count > 1 {
+            let queryString = String(components[1])
+            let queryParams = parseQueryParams(queryString)
+            if let w = queryParams["width"], let wInt = Int(w) { width = wInt }
+            if let h = queryParams["height"], let hInt = Int(h) { height = hInt }
+        }
+
+        guard !key.isEmpty else {
+            sendResponse(connection: connection, status: 400, body: Data("Missing image key".utf8))
+            return
+        }
+
+        // Fetch image
+        if let imageData = await RoonImageProvider.shared.fetchImage(key: key, width: width, height: height) {
+            sendResponse(
+                connection: connection,
+                status: 200,
+                contentType: "image/jpeg",
+                cacheControl: "public, max-age=86400",
+                body: imageData
+            )
+        } else {
+            sendResponse(connection: connection, status: 404, body: Data("Image not found".utf8))
+        }
+    }
+
+    private static func parseQueryParams(_ query: String) -> [String: String] {
+        var params: [String: String] = [:]
+        for pair in query.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1)
+            if kv.count == 2 {
+                params[String(kv[0])] = String(kv[1])
+            }
+        }
+        return params
+    }
+
+    // MARK: - HTTP Response
+
+    private static func sendResponse(
+        connection: NWConnection,
+        status: Int,
+        contentType: String = "text/plain",
+        cacheControl: String? = nil,
+        body: Data
+    ) {
+        let statusText: String
+        switch status {
+        case 200: statusText = "OK"
+        case 400: statusText = "Bad Request"
+        case 404: statusText = "Not Found"
+        case 405: statusText = "Method Not Allowed"
+        default: statusText = "Error"
+        }
+
+        var header = "HTTP/1.1 \(status) \(statusText)\r\n"
+        header += "Content-Type: \(contentType)\r\n"
+        header += "Content-Length: \(body.count)\r\n"
+        header += "Access-Control-Allow-Origin: *\r\n"
+        if let cache = cacheControl {
+            header += "Cache-Control: \(cache)\r\n"
+        }
+        header += "Connection: close\r\n"
+        header += "\r\n"
+
+        var responseData = Data(header.utf8)
+        responseData.append(body)
+
+        connection.send(content: responseData, completion: .contentProcessed { _ in
+            connection.cancel()
+        })
+    }
+}

--- a/RoonController/Services/Roon/Image/RoonImageCache.swift
+++ b/RoonController/Services/Roon/Image/RoonImageCache.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+// MARK: - Roon Image Cache
+
+/// Two-tier image cache: NSCache (memory) + disk cache in app's Caches directory.
+/// Cache keys are derived from image_key + dimensions.
+actor RoonImageCache {
+
+    static let shared = RoonImageCache()
+
+    // MARK: - Memory Cache
+
+    private let memoryCache = NSCache<NSString, NSData>()
+    private let maxMemoryItems = 200
+
+    // MARK: - Disk Cache
+
+    private let diskCacheDir: URL
+    private let maxDiskAge: TimeInterval = 7 * 24 * 3600 // 7 days
+
+    init() {
+        let cacheBase: URL
+        if let container = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
+            cacheBase = container
+        } else {
+            cacheBase = FileManager.default.temporaryDirectory
+        }
+        diskCacheDir = cacheBase.appendingPathComponent("RoonImages", isDirectory: true)
+
+        memoryCache.countLimit = maxMemoryItems
+
+        // Create disk cache directory
+        try? FileManager.default.createDirectory(at: diskCacheDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Cache Key
+
+    static func cacheKey(imageKey: String, width: Int, height: Int) -> String {
+        "\(imageKey)_\(width)x\(height)"
+    }
+
+    // MARK: - Get
+
+    func get(key: String) -> Data? {
+        // Check memory cache first
+        if let data = memoryCache.object(forKey: key as NSString) {
+            return data as Data
+        }
+
+        // Check disk cache
+        let fileURL = diskCacheDir.appendingPathComponent(safeFileName(key))
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
+
+        // Check age
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path),
+           let modDate = attrs[.modificationDate] as? Date,
+           Date().timeIntervalSince(modDate) > maxDiskAge {
+            try? FileManager.default.removeItem(at: fileURL)
+            return nil
+        }
+
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+
+        // Promote to memory cache
+        memoryCache.setObject(data as NSData, forKey: key as NSString)
+        return data
+    }
+
+    // MARK: - Store
+
+    func store(key: String, data: Data) {
+        // Memory cache
+        memoryCache.setObject(data as NSData, forKey: key as NSString)
+
+        // Disk cache
+        let fileURL = diskCacheDir.appendingPathComponent(safeFileName(key))
+        try? data.write(to: fileURL)
+    }
+
+    // MARK: - Eviction
+
+    func evictExpired() {
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: diskCacheDir, includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+
+        let now = Date()
+        for file in files {
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: file.path),
+               let modDate = attrs[.modificationDate] as? Date,
+               now.timeIntervalSince(modDate) > maxDiskAge {
+                try? FileManager.default.removeItem(at: file)
+            }
+        }
+    }
+
+    func clearAll() {
+        memoryCache.removeAllObjects()
+        try? FileManager.default.removeItem(at: diskCacheDir)
+        try? FileManager.default.createDirectory(at: diskCacheDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Helpers
+
+    private func safeFileName(_ key: String) -> String {
+        // Use a hash to avoid filesystem issues with special characters
+        let hash = key.data(using: .utf8)!.withUnsafeBytes { bytes -> String in
+            var hasher = Hasher()
+            hasher.combine(bytes: UnsafeRawBufferPointer(bytes))
+            let value = hasher.finalize()
+            return String(format: "%016lx", abs(value))
+        }
+        return hash
+    }
+}

--- a/RoonController/Services/Roon/Image/RoonImageProvider.swift
+++ b/RoonController/Services/Roon/Image/RoonImageProvider.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+// MARK: - Roon Image Provider
+
+/// Coordinates image fetching from Roon Core with the two-tier cache.
+/// Used by LocalImageServer to serve images to SwiftUI AsyncImage views.
+actor RoonImageProvider {
+
+    static let shared = RoonImageProvider()
+
+    private var imageService: RoonImageService?
+    private var inFlightRequests: [String: Task<Data?, Never>] = [:]
+
+    // MARK: - Configuration
+
+    func setImageService(_ service: RoonImageService?) {
+        self.imageService = service
+    }
+
+    // MARK: - Fetch Image
+
+    /// Fetch an image by key and dimensions. Returns cached data or fetches from Core.
+    func fetchImage(key: String, width: Int = 300, height: Int = 300) async -> Data? {
+        let cacheKey = RoonImageCache.cacheKey(imageKey: key, width: width, height: height)
+
+        // Check cache first
+        if let cached = await RoonImageCache.shared.get(key: cacheKey) {
+            return cached
+        }
+
+        // Deduplicate in-flight requests
+        if let existing = inFlightRequests[cacheKey] {
+            return await existing.value
+        }
+
+        let task = Task<Data?, Never> { [weak self] in
+            guard let self = self else { return nil }
+            let service = await self.imageService
+            guard let service = service else { return nil }
+
+            let options = RoonImageService.ImageOptions(
+                scale: "fit",
+                width: width,
+                height: height,
+                format: "image/jpeg"
+            )
+
+            do {
+                if let data = try await service.getImage(key: key, options: options), !data.isEmpty {
+                    await RoonImageCache.shared.store(key: cacheKey, data: data)
+                    return data
+                }
+            } catch {
+                // Fetch failed
+            }
+            return nil
+        }
+
+        inFlightRequests[cacheKey] = task
+        let result = await task.value
+        inFlightRequests.removeValue(forKey: cacheKey)
+        return result
+    }
+}

--- a/RoonController/Services/Roon/Protocol/MOOMessage.swift
+++ b/RoonController/Services/Roon/Protocol/MOOMessage.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+// MARK: - MOO Protocol Message
+
+/// Represents a MOO/1 protocol message used by Roon Core.
+/// Format: `MOO/1 {VERB} {name}\nHeader: value\n...\n\n{body}`
+struct MOOMessage {
+
+    enum Verb: String {
+        case request = "REQUEST"
+        case complete = "COMPLETE"
+        case `continue` = "CONTINUE"
+    }
+
+    let verb: Verb
+    let name: String
+    let requestId: Int
+    let headers: [String: String]
+    let body: Data?
+
+    // MARK: - Convenience accessors
+
+    var isSuccess: Bool {
+        headers["Roon-Status"]?.lowercased() == "success" || headers["Roon-Status"] == nil
+    }
+
+    var contentType: String? {
+        headers["Content-Type"]
+    }
+
+    var isJSON: Bool {
+        guard let ct = contentType else { return body != nil }
+        return ct.contains("application/json")
+    }
+
+    /// Decode body as JSON
+    func decodeBody<T: Decodable>(_ type: T.Type) -> T? {
+        guard let body = body else { return nil }
+        return try? JSONDecoder().decode(type, from: body)
+    }
+
+    /// Body as JSON dictionary
+    var bodyJSON: [String: Any]? {
+        guard let body = body else { return nil }
+        return try? JSONSerialization.jsonObject(with: body) as? [String: Any]
+    }
+
+    // MARK: - Parsing
+
+    /// Parse a MOO message from raw WebSocket binary data.
+    static func parse(_ data: Data) -> MOOMessage? {
+        // Find the header/body separator: \n\n
+        guard let separatorRange = findHeaderSeparator(in: data) else { return nil }
+
+        let headerData = data[data.startIndex..<separatorRange.lowerBound]
+        guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
+
+        let bodyStart = separatorRange.upperBound
+        let body: Data? = bodyStart < data.endIndex ? data[bodyStart..<data.endIndex] : nil
+
+        // Parse first line: "MOO/1 VERB name"
+        let lines = headerString.components(separatedBy: "\n")
+        guard let firstLine = lines.first else { return nil }
+
+        let parts = firstLine.split(separator: " ", maxSplits: 2)
+        guard parts.count >= 3,
+              parts[0] == "MOO/1",
+              let verb = Verb(rawValue: String(parts[1])) else { return nil }
+
+        let name = String(parts[2])
+
+        // Parse headers
+        var headers: [String: String] = [:]
+        var requestId: Int?
+
+        for i in 1..<lines.count {
+            let line = lines[i]
+            if line.isEmpty { continue }
+            guard let colonIndex = line.firstIndex(of: ":") else { continue }
+            let key = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+            let value = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+
+            if key == "Request-Id" {
+                requestId = Int(value)
+            } else {
+                headers[key] = value
+            }
+        }
+
+        guard let rid = requestId else { return nil }
+
+        return MOOMessage(verb: verb, name: name, requestId: rid, headers: headers, body: body)
+    }
+
+    // MARK: - Building
+
+    /// Build a MOO REQUEST message.
+    static func request(name: String, requestId: Int, body: Data? = nil) -> Data {
+        build(verb: .request, name: name, requestId: requestId, body: body)
+    }
+
+    /// Build a MOO REQUEST message with a JSON-encodable body.
+    static func request<T: Encodable>(name: String, requestId: Int, body: T) -> Data {
+        let jsonData = try? JSONEncoder().encode(body)
+        return build(verb: .request, name: name, requestId: requestId, body: jsonData)
+    }
+
+    /// Build a MOO REQUEST message with a JSON dictionary body.
+    static func request(name: String, requestId: Int, jsonBody: [String: Any]) -> Data {
+        let jsonData = try? JSONSerialization.data(withJSONObject: jsonBody)
+        return build(verb: .request, name: name, requestId: requestId, body: jsonData)
+    }
+
+    /// Build a MOO COMPLETE response (for responding to Core requests like ping).
+    static func complete(name: String, requestId: Int, body: Data? = nil) -> Data {
+        build(verb: .complete, name: name, requestId: requestId, body: body)
+    }
+
+    /// Build a MOO CONTINUE response.
+    static func continueMessage(name: String, requestId: Int, body: Data? = nil) -> Data {
+        build(verb: .continue, name: name, requestId: requestId, body: body)
+    }
+
+    // MARK: - Internal
+
+    private static func build(verb: Verb, name: String, requestId: Int, body: Data?) -> Data {
+        var header = "MOO/1 \(verb.rawValue) \(name)\nRequest-Id: \(requestId)"
+
+        if let body = body, !body.isEmpty {
+            header += "\nContent-Type: application/json"
+            header += "\nContent-Length: \(body.count)"
+        }
+
+        header += "\n\n"
+
+        var result = Data(header.utf8)
+        if let body = body {
+            result.append(body)
+        }
+        return result
+    }
+
+    /// Find the \n\n separator between headers and body.
+    private static func findHeaderSeparator(in data: Data) -> Range<Data.Index>? {
+        let newline = UInt8(ascii: "\n")
+        var i = data.startIndex
+        while i < data.endIndex {
+            if data[i] == newline {
+                let next = data.index(after: i)
+                if next < data.endIndex && data[next] == newline {
+                    return i..<data.index(after: next)
+                }
+            }
+            i = data.index(after: i)
+        }
+        return nil
+    }
+}
+
+// MARK: - Request ID Generator
+
+/// Thread-safe atomic request ID generator for MOO protocol.
+final class MOORequestIdGenerator: @unchecked Sendable {
+    private var _nextId: Int = 1
+    private let lock = NSLock()
+
+    func next() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = _nextId
+        _nextId += 1
+        return id
+    }
+}

--- a/RoonController/Services/Roon/Protocol/MOOTransport.swift
+++ b/RoonController/Services/Roon/Protocol/MOOTransport.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+// MARK: - MOO WebSocket Transport
+
+/// Manages a binary WebSocket connection to a Roon Core using the MOO/1 protocol.
+/// Handles ping/pong keepalive every 10s and automatic reconnection.
+actor MOOTransport {
+
+    enum State: Sendable {
+        case disconnected
+        case connecting
+        case connected
+        case failed(String)
+    }
+
+    // MARK: - Properties
+
+    private(set) var state: State = .disconnected
+    private var webSocket: URLSessionWebSocketTask?
+    private let session = URLSession(configuration: .default)
+    private var pingTask: Task<Void, Never>?
+    private var receiveTask: Task<Void, Never>?
+
+    private var _onMessage: (@Sendable (MOOMessage) -> Void)?
+    private var _onStateChange: (@Sendable (State) -> Void)?
+
+    var onMessage: (@Sendable (MOOMessage) -> Void)? {
+        get { _onMessage }
+        set { _onMessage = newValue }
+    }
+
+    var onStateChange: (@Sendable (State) -> Void)? {
+        get { _onStateChange }
+        set { _onStateChange = newValue }
+    }
+
+    // MARK: - Connect / Disconnect
+
+    func connect(host: String, port: Int) {
+        disconnect()
+
+        let urlString = "ws://\(host):\(port)/api"
+        guard let url = URL(string: urlString) else {
+            updateState(.failed("Invalid URL: \(urlString)"))
+            return
+        }
+
+        updateState(.connecting)
+
+        let ws = session.webSocketTask(with: url)
+        ws.maximumMessageSize = 16 * 1024 * 1024
+        self.webSocket = ws
+        ws.resume()
+
+        updateState(.connected)
+        startReceiveLoop()
+        startPingLoop()
+    }
+
+    func disconnect() {
+        pingTask?.cancel()
+        pingTask = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocket?.cancel(with: .goingAway, reason: nil)
+        webSocket = nil
+        updateState(.disconnected)
+    }
+
+    // MARK: - Send
+
+    func send(_ data: Data) async throws {
+        guard let ws = webSocket else {
+            throw MOOTransportError.notConnected
+        }
+        try await ws.send(.data(data))
+    }
+
+    // MARK: - Receive Loop
+
+    private func startReceiveLoop() {
+        receiveTask?.cancel()
+        let ws = webSocket
+        let handler = _onMessage
+        receiveTask = Task { [weak self] in
+            guard let ws = ws else { return }
+            while !Task.isCancelled {
+                do {
+                    let message = try await ws.receive()
+                    let data: Data
+                    switch message {
+                    case .data(let d):
+                        data = d
+                    case .string(let s):
+                        data = Data(s.utf8)
+                    @unknown default:
+                        continue
+                    }
+                    if let moo = MOOMessage.parse(data) {
+                        handler?(moo)
+                    }
+                } catch {
+                    if !Task.isCancelled {
+                        await self?.handleDisconnect()
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - Ping/Pong Keepalive
+
+    private func startPingLoop() {
+        pingTask?.cancel()
+        let ws = webSocket
+        pingTask = Task { [weak self] in
+            guard let ws = ws else { return }
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(nanoseconds: 10_000_000_000)
+                    guard !Task.isCancelled else { break }
+                    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                        ws.sendPing { error in
+                            if let error = error {
+                                cont.resume(throwing: error)
+                            } else {
+                                cont.resume()
+                            }
+                        }
+                    }
+                } catch {
+                    if !Task.isCancelled {
+                        await self?.handleDisconnect()
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func handleDisconnect() {
+        pingTask?.cancel()
+        pingTask = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocket = nil
+        updateState(.disconnected)
+    }
+
+    private func updateState(_ newState: State) {
+        state = newState
+        _onStateChange?(newState)
+    }
+}
+
+// MARK: - Errors
+
+enum MOOTransportError: Error, LocalizedError {
+    case notConnected
+    case timeout
+
+    var errorDescription: String? {
+        switch self {
+        case .notConnected: return "MOO transport not connected"
+        case .timeout: return "MOO request timed out"
+        }
+    }
+}

--- a/RoonController/Services/Roon/Protocol/SOODDiscovery.swift
+++ b/RoonController/Services/Roon/Protocol/SOODDiscovery.swift
@@ -1,0 +1,362 @@
+import Foundation
+import Network
+
+// MARK: - SOOD Discovery Protocol
+
+/// Discovers Roon Core instances on the local network using the SOOD protocol.
+/// SOOD uses UDP multicast on 239.255.90.90:9003 with a proprietary binary format:
+/// `"SOOD" + 0x02 + 'Q'/'R' + properties`
+actor SOODDiscovery {
+
+    struct DiscoveredCore: Sendable, Equatable {
+        let coreId: String
+        let displayName: String
+        let host: String
+        let port: Int
+    }
+
+    // MARK: - Constants
+
+    private static let multicastGroup = "239.255.90.90"
+    private static let soodPort: UInt16 = 9003
+    private static let magic = Data([0x53, 0x4F, 0x4F, 0x44]) // "SOOD"
+    private static let version: UInt8 = 0x02
+    private static let typeQuery: UInt8 = 0x51 // 'Q'
+    private static let typeReply: UInt8 = 0x52 // 'R'
+
+    // MARK: - Properties
+
+    private var connection: NWConnection?
+    private var listener: NWListener?
+    private var receiveTask: Task<Void, Never>?
+    private var queryTask: Task<Void, Never>?
+    private var discoveredCores: [String: DiscoveredCore] = [:]
+
+    var onCoreDiscovered: ((DiscoveredCore) -> Void)?
+
+    // MARK: - Start / Stop
+
+    func start() {
+        stop()
+        startListening()
+        startQueryLoop()
+    }
+
+    func stop() {
+        queryTask?.cancel()
+        queryTask = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        listener?.cancel()
+        listener = nil
+        connection?.cancel()
+        connection = nil
+        discoveredCores.removeAll()
+    }
+
+    func getDiscoveredCores() -> [DiscoveredCore] {
+        Array(discoveredCores.values)
+    }
+
+    // MARK: - Listening for SOOD replies
+
+    private func startListening() {
+        let params = NWParameters.udp
+        params.allowLocalEndpointReuse = true
+        params.requiredInterfaceType = .other
+
+        do {
+            let listener = try NWListener(using: params, on: NWEndpoint.Port(rawValue: 0)!)
+            self.listener = listener
+
+            listener.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    break
+                case .failed:
+                    Task { [weak self] in await self?.restartListening() }
+                default:
+                    break
+                }
+            }
+
+            listener.newConnectionHandler = { [weak self] connection in
+                connection.start(queue: .global(qos: .utility))
+                Task { await self?.receiveSOODData(on: connection) }
+            }
+
+            listener.start(queue: .global(qos: .utility))
+        } catch {
+            // Listener failed to start
+        }
+    }
+
+    private func restartListening() {
+        listener?.cancel()
+        listener = nil
+        startListening()
+    }
+
+    private nonisolated func receiveSOODData(on connection: NWConnection) async {
+        connection.receiveMessage { [weak self] data, _, _, error in
+            guard let data = data, error == nil else { return }
+            Task { await self?.handleSOODReply(data, from: connection) }
+        }
+    }
+
+    // MARK: - Sending SOOD queries
+
+    private func startQueryLoop() {
+        queryTask?.cancel()
+        queryTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.sendQuery()
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000) // 5s between queries
+                } catch {
+                    break
+                }
+            }
+        }
+    }
+
+    private func sendQuery() {
+        let queryPacket = buildQueryPacket()
+
+        let params = NWParameters.udp
+        params.allowLocalEndpointReuse = true
+
+        let host = NWEndpoint.Host(Self.multicastGroup)
+        let port = NWEndpoint.Port(rawValue: Self.soodPort)!
+        let endpoint = NWEndpoint.hostPort(host: host, port: port)
+        let connection = NWConnection(to: endpoint, using: params)
+
+        connection.stateUpdateHandler = { state in
+            switch state {
+            case .ready:
+                connection.send(content: queryPacket, completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            case .failed, .cancelled:
+                break
+            default:
+                break
+            }
+        }
+
+        connection.start(queue: .global(qos: .utility))
+
+        // Also send via direct UDP to common ports for discovery
+        sendDirectQuery(queryPacket)
+    }
+
+    private func sendDirectQuery(_ packet: Data) {
+        // Roon Core listens on port 9003 for SOOD queries
+        // Send on all available network interfaces
+        let interfaces = getNetworkInterfaces()
+        for iface in interfaces {
+            let broadcastAddr = iface.broadcast ?? "255.255.255.255"
+            let params = NWParameters.udp
+            params.allowLocalEndpointReuse = true
+
+            let host = NWEndpoint.Host(broadcastAddr)
+            let port = NWEndpoint.Port(rawValue: Self.soodPort)!
+            let conn = NWConnection(to: .hostPort(host: host, port: port), using: params)
+
+            conn.stateUpdateHandler = { state in
+                if state == .ready {
+                    conn.send(content: packet, completion: .contentProcessed { _ in
+                        conn.cancel()
+                    })
+                }
+            }
+            conn.start(queue: .global(qos: .utility))
+        }
+    }
+
+    // MARK: - Packet Building
+
+    private func buildQueryPacket() -> Data {
+        var data = Data()
+        data.append(Self.magic)
+        data.append(Self.version)
+        data.append(Self.typeQuery)
+
+        // Add query_service_id property for Roon
+        let queryServiceId = "00720724-5143-4a9b-abac-0e50cba674bb"
+        appendProperty(&data, key: "_tid", value: UUID().uuidString)
+        appendProperty(&data, key: "query_service_id", value: queryServiceId)
+
+        return data
+    }
+
+    /// Append a SOOD property: `type(1) + key_len(2 BE) + key + value_len(2 BE) + value`
+    private func appendProperty(_ data: inout Data, key: String, value: String) {
+        let keyData = Data(key.utf8)
+        let valueData = Data(value.utf8)
+
+        // Type byte: 0x01 for UTF-8 string
+        data.append(0x01)
+
+        // Key length (big-endian 16-bit)
+        var keyLen = UInt16(keyData.count).bigEndian
+        data.append(Data(bytes: &keyLen, count: 2))
+        data.append(keyData)
+
+        // Value length (big-endian 16-bit)
+        var valueLen = UInt16(valueData.count).bigEndian
+        data.append(Data(bytes: &valueLen, count: 2))
+        data.append(valueData)
+    }
+
+    // MARK: - Packet Parsing
+
+    private func handleSOODReply(_ data: Data, from connection: NWConnection) {
+        guard data.count >= 6 else { return }
+
+        // Verify magic
+        guard data[data.startIndex..<data.startIndex + 4] == Self.magic else { return }
+        guard data[data.startIndex + 4] == Self.version else { return }
+        guard data[data.startIndex + 5] == Self.typeReply else { return }
+
+        // Parse properties
+        let properties = parseProperties(data, from: data.startIndex + 6)
+
+        guard let serviceId = properties["service_id"],
+              let httpPort = properties["http_port"],
+              let port = Int(httpPort) else { return }
+
+        // Get host from the connection's remote endpoint
+        let host: String
+        if let name = properties["name"] {
+            // Try to get host from properties first
+            host = properties["host"] ?? extractHost(from: connection) ?? name
+        } else {
+            host = extractHost(from: connection) ?? "unknown"
+        }
+
+        let displayName = properties["display_name"] ?? properties["name"] ?? serviceId
+
+        let core = DiscoveredCore(
+            coreId: serviceId,
+            displayName: displayName,
+            host: host,
+            port: port
+        )
+
+        if discoveredCores[serviceId] == nil || discoveredCores[serviceId] != core {
+            discoveredCores[serviceId] = core
+            onCoreDiscovered?(core)
+        }
+    }
+
+    /// Parse SOOD properties from binary data.
+    private func parseProperties(_ data: Data, from offset: Data.Index) -> [String: String] {
+        var properties: [String: String] = [:]
+        var pos = offset
+
+        while pos < data.endIndex {
+            guard pos + 1 <= data.endIndex else { break }
+            let type = data[pos]
+            pos = data.index(after: pos)
+
+            guard type == 0x01 else { break } // Only handle UTF-8 string type
+
+            // Key length (big-endian 16-bit)
+            guard pos + 2 <= data.endIndex else { break }
+            let keyLen = Int(UInt16(data[pos]) << 8 | UInt16(data[data.index(after: pos)]))
+            pos = data.index(pos, offsetBy: 2)
+
+            guard pos + keyLen <= data.endIndex else { break }
+            let key = String(data: data[pos..<data.index(pos, offsetBy: keyLen)], encoding: .utf8) ?? ""
+            pos = data.index(pos, offsetBy: keyLen)
+
+            // Value length (big-endian 16-bit)
+            guard pos + 2 <= data.endIndex else { break }
+            let valueLen = Int(UInt16(data[pos]) << 8 | UInt16(data[data.index(after: pos)]))
+            pos = data.index(pos, offsetBy: 2)
+
+            guard pos + valueLen <= data.endIndex else { break }
+            let value = String(data: data[pos..<data.index(pos, offsetBy: valueLen)], encoding: .utf8) ?? ""
+            pos = data.index(pos, offsetBy: valueLen)
+
+            properties[key] = value
+        }
+
+        return properties
+    }
+
+    private nonisolated func extractHost(from connection: NWConnection) -> String? {
+        if case .hostPort(let host, _) = connection.currentPath?.remoteEndpoint {
+            switch host {
+            case .ipv4(let addr):
+                return "\(addr)"
+            case .ipv6(let addr):
+                return "\(addr)"
+            case .name(let name, _):
+                return name
+            @unknown default:
+                return nil
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Network Interfaces
+
+    private struct NetworkInterface {
+        let name: String
+        let address: String
+        let broadcast: String?
+    }
+
+    private nonisolated func getNetworkInterfaces() -> [NetworkInterface] {
+        var interfaces: [NetworkInterface] = []
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+
+        guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else { return interfaces }
+        defer { freeifaddrs(firstAddr) }
+
+        var ptr = firstAddr
+        while true {
+            let iface = ptr.pointee
+            let family = iface.ifa_addr.pointee.sa_family
+
+            if family == UInt8(AF_INET) { // IPv4 only
+                let name = String(cString: iface.ifa_name)
+                // Skip loopback
+                if name != "lo0" {
+                    var addr = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                    var sockAddr = iface.ifa_addr.pointee
+                    withUnsafePointer(to: &sockAddr) { sockPtr in
+                        sockPtr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { inPtr in
+                            var inAddr = inPtr.pointee.sin_addr
+                            inet_ntop(AF_INET, &inAddr, &addr, socklen_t(INET_ADDRSTRLEN))
+                        }
+                    }
+                    let address = String(cString: addr)
+
+                    var broadcastStr: String?
+                    if let broadcastAddr = iface.ifa_dstaddr {
+                        var bcast = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+                        var bSockAddr = broadcastAddr.pointee
+                        withUnsafePointer(to: &bSockAddr) { sockPtr in
+                            sockPtr.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { inPtr in
+                                var inAddr = inPtr.pointee.sin_addr
+                                inet_ntop(AF_INET, &inAddr, &bcast, socklen_t(INET_ADDRSTRLEN))
+                            }
+                        }
+                        broadcastStr = String(cString: bcast)
+                    }
+
+                    interfaces.append(NetworkInterface(name: name, address: address, broadcast: broadcastStr))
+                }
+            }
+
+            guard let next = iface.ifa_next else { break }
+            ptr = next
+        }
+
+        return interfaces
+    }
+}

--- a/RoonController/Services/Roon/Services/RoonBrowseService.swift
+++ b/RoonController/Services/Roon/Services/RoonBrowseService.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// MARK: - Roon Browse Service
+
+/// Wraps Roon browse API calls: browse hierarchy navigation, load items, search.
+/// All JSON serialization happens before crossing the actor boundary.
+struct RoonBrowseService: Sendable {
+
+    let connection: RoonConnection
+    let sessionKey: String
+
+    init(connection: RoonConnection, sessionKey: String = "main") {
+        self.connection = connection
+        self.sessionKey = sessionKey
+    }
+
+    // MARK: - Browse
+
+    struct BrowseResponse {
+        let action: String?
+        let list: [String: Any]?
+        let items: [[String: Any]]
+
+        // Sendable-safe initializer from raw data
+        init(action: String?, listData: Data?, itemsData: Data?) {
+            self.action = action
+            if let listData = listData {
+                self.list = (try? JSONSerialization.jsonObject(with: listData)) as? [String: Any]
+            } else {
+                self.list = nil
+            }
+            if let itemsData = itemsData {
+                self.items = (try? JSONSerialization.jsonObject(with: itemsData)) as? [[String: Any]] ?? []
+            } else {
+                self.items = []
+            }
+        }
+
+        init(action: String?, list: [String: Any]?, items: [[String: Any]]) {
+            self.action = action
+            self.list = list
+            self.items = items
+        }
+    }
+
+    func browse(
+        hierarchy: String = "browse",
+        zoneId: String? = nil,
+        itemKey: String? = nil,
+        input: String? = nil,
+        popLevels: Int? = nil,
+        popAll: Bool = false
+    ) async throws -> BrowseResponse {
+        let serviceName = await connection.browseService()
+
+        var body: [String: Any] = [
+            "hierarchy": hierarchy,
+            "multi_session_key": sessionKey
+        ]
+        if let zoneId = zoneId { body["zone_or_output_id"] = zoneId }
+        if let itemKey = itemKey { body["item_key"] = itemKey }
+        if let input = input { body["input"] = input }
+        if let popLevels = popLevels { body["pop_levels"] = popLevels }
+        if popAll { body["pop_all"] = true }
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        let response = try await connection.sendRequestData(name: "\(serviceName)/browse", bodyData: bodyData)
+        let json = response.bodyJSON ?? [:]
+
+        let action = json["action"] as? String
+        let list = json["list"] as? [String: Any]
+        let listCount = (list?["count"] as? Int) ?? 0
+
+        if listCount > 0 {
+            let loadResult = try await load(hierarchy: hierarchy, offset: 0, count: 100)
+            return BrowseResponse(action: action, list: list, items: loadResult.items)
+        }
+
+        return BrowseResponse(action: action, list: list, items: [])
+    }
+
+    // MARK: - Load
+
+    struct LoadResponse {
+        let list: [String: Any]?
+        let items: [[String: Any]]
+        let offset: Int
+
+        init(list: [String: Any]?, items: [[String: Any]], offset: Int) {
+            self.list = list
+            self.items = items
+            self.offset = offset
+        }
+    }
+
+    func load(
+        hierarchy: String = "browse",
+        offset: Int = 0,
+        count: Int = 100
+    ) async throws -> LoadResponse {
+        let serviceName = await connection.browseService()
+
+        let body: [String: Any] = [
+            "hierarchy": hierarchy,
+            "multi_session_key": sessionKey,
+            "offset": offset,
+            "count": count
+        ]
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        let response = try await connection.sendRequestData(name: "\(serviceName)/load", bodyData: bodyData)
+        let json = response.bodyJSON ?? [:]
+
+        let list = json["list"] as? [String: Any]
+        let items = json["items"] as? [[String: Any]] ?? []
+        let resultOffset = json["offset"] as? Int ?? offset
+
+        return LoadResponse(list: list, items: items, offset: resultOffset)
+    }
+}

--- a/RoonController/Services/Roon/Services/RoonImageService.swift
+++ b/RoonController/Services/Roon/Services/RoonImageService.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - Roon Image Service
+
+/// Fetches images from Roon Core via the MOO image API.
+/// Images are returned as raw binary data (JPEG or PNG).
+struct RoonImageService: Sendable {
+
+    let connection: RoonConnection
+
+    init(connection: RoonConnection) {
+        self.connection = connection
+    }
+
+    // MARK: - Get Image
+
+    struct ImageOptions: Sendable {
+        var scale: String = "fit"
+        var width: Int = 300
+        var height: Int = 300
+        var format: String = "image/jpeg"
+    }
+
+    /// Fetch an image from Roon Core by its image key.
+    func getImage(key: String, options: ImageOptions = ImageOptions()) async throws -> Data? {
+        let serviceName = await connection.imageService()
+
+        let body: [String: Any] = [
+            "image_key": key,
+            "scale": options.scale,
+            "width": options.width,
+            "height": options.height,
+            "format": options.format
+        ]
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        let response = try await connection.sendRequestData(name: "\(serviceName)/get_image", bodyData: bodyData)
+        return response.body
+    }
+}

--- a/RoonController/Services/Roon/Services/RoonStatusService.swift
+++ b/RoonController/Services/Roon/Services/RoonStatusService.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+// MARK: - Roon Status Service (Provided)
+
+/// Service provided by this extension to the Roon Core.
+/// Responds to ping requests and provides extension status.
+/// Note: Most of this is handled directly in RoonConnection's handleCoreRequest,
+/// but this struct provides the message formatting utilities.
+struct RoonStatusService {
+
+    /// Build a ping response.
+    static func pingResponse(requestId: Int) -> Data {
+        MOOMessage.complete(name: "Success", requestId: requestId)
+    }
+
+    /// Build a status subscription response.
+    static func statusResponse(requestId: Int, message: String = "Ready", isError: Bool = false) -> Data {
+        let body = RoonRegistration.statusBody(message: message, isError: isError)
+        let jsonData = try? JSONSerialization.data(withJSONObject: body)
+        return MOOMessage.complete(name: "Subscribed", requestId: requestId, body: jsonData)
+    }
+
+    /// Build a status update (CONTINUE) for an active subscription.
+    static func statusUpdate(requestId: Int, message: String, isError: Bool = false) -> Data {
+        let body = RoonRegistration.statusBody(message: message, isError: isError)
+        let jsonData = try? JSONSerialization.data(withJSONObject: body)
+        return MOOMessage.continueMessage(name: "Changed", requestId: requestId, body: jsonData)
+    }
+}

--- a/RoonController/Services/Roon/Services/RoonTransportService.swift
+++ b/RoonController/Services/Roon/Services/RoonTransportService.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// MARK: - Roon Transport Service
+
+/// Wraps Roon transport API calls: playback control, seek, volume, settings, queue.
+/// All JSON serialization happens before crossing the actor boundary.
+struct RoonTransportService: Sendable {
+
+    let connection: RoonConnection
+
+    init(connection: RoonConnection) {
+        self.connection = connection
+    }
+
+    // MARK: - Playback Control
+
+    func control(zoneId: String, control: String) async throws {
+        let serviceName = await connection.transportService()
+        let body: [String: Any] = ["zone_or_output_id": zoneId, "control": control]
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/control", bodyData: bodyData)
+    }
+
+    // MARK: - Seek
+
+    func seek(zoneId: String, how: String, seconds: Int) async throws {
+        let serviceName = await connection.transportService()
+        let body: [String: Any] = ["zone_or_output_id": zoneId, "how": how, "seconds": seconds]
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/seek", bodyData: bodyData)
+    }
+
+    // MARK: - Volume
+
+    func changeVolume(outputId: String, how: String, value: Double) async throws {
+        let serviceName = await connection.transportService()
+        let body: [String: Any] = ["output_id": outputId, "how": how, "value": Int(value)]
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/change_volume", bodyData: bodyData)
+    }
+
+    // MARK: - Mute
+
+    func mute(outputId: String, how: String) async throws {
+        let serviceName = await connection.transportService()
+        let body: [String: Any] = ["output_id": outputId, "how": how]
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/mute", bodyData: bodyData)
+    }
+
+    // MARK: - Settings
+
+    func changeSettings(zoneId: String, settings: [String: any Sendable]) async throws {
+        let serviceName = await connection.transportService()
+        var body: [String: Any] = ["zone_or_output_id": zoneId]
+        for (key, value) in settings { body[key] = value }
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/change_settings", bodyData: bodyData)
+    }
+
+    // MARK: - Queue
+
+    func subscribeQueue(zoneId: String) async {
+        await connection.subscribeQueue(zoneId: zoneId)
+    }
+
+    func playFromHere(zoneId: String, queueItemId: Int) async throws {
+        let serviceName = await connection.transportService()
+        let body: [String: Any] = ["zone_or_output_id": zoneId, "queue_item_id": queueItemId]
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        _ = try await connection.sendRequestData(name: "\(serviceName)/play_from_here", bodyData: bodyData)
+    }
+}

--- a/RoonController/Views/ConnectionView.swift
+++ b/RoonController/Views/ConnectionView.swift
@@ -21,7 +21,7 @@ struct ConnectionView: View {
                     .fontWeight(.semibold)
                     .foregroundStyle(Color.roonText)
 
-                Text("Assurez-vous que le backend Node.js est lance sur le port \(roonService.backendPort).")
+                Text("Recherche du Roon Core sur le reseau local via SOOD...")
                     .foregroundStyle(Color.roonSecondary)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 400)
@@ -34,11 +34,11 @@ struct ConnectionView: View {
                             ProgressView()
                                 .controlSize(.small)
                                 .tint(Color.roonSecondary)
-                            Text("Connexion au backend...")
+                            Text("Connexion au Roon Core...")
                                 .foregroundStyle(Color.roonSecondary)
                         }
                     case .disconnected:
-                        Label("Deconnecte du backend", systemImage: "xmark.circle")
+                        Label("Deconnecte du Roon Core", systemImage: "xmark.circle")
                             .foregroundStyle(.red)
                     case .connected:
                         Label("Connecte — en attente des zones...", systemImage: "checkmark.circle")
@@ -81,7 +81,7 @@ struct ConnectionView: View {
                     }
                 }
 
-                Button("Reconnecter au backend") {
+                Button("Reconnecter") {
                     roonService.disconnect()
                     roonService.connect()
                 }


### PR DESCRIPTION
Implement MOO/SOOD protocols directly in Swift, eliminating the dependency on the Node.js backend. The app now communicates with Roon Core natively via WebSocket binary (MOO) and UDP multicast discovery (SOOD).

New files (12):
- Protocol layer: MOOMessage, MOOTransport, SOODDiscovery
- Core layer: RoonConnection (orchestrator), RoonRegistration (tokens)
- Services: RoonTransportService, RoonBrowseService, RoonImageService, RoonStatusService
- Image infra: RoonImageCache, RoonImageProvider, LocalImageServer (port 9150)

Modified files (5):
- RoonService.swift: same public API, internals now use RoonConnection
- RoonControllerApp.swift: removed ensureBackendRunning()
- ConnectionView/SettingsView: updated UI text (no more backend references)
- Tests: updated image URL assertions, added MOO protocol tests