### PR TITLE
Release v1.1.1 — Community feedback fixes + Roon favorites

### DIFF
--- a/RoonController/RoonController.xcodeproj/project.pbxproj
+++ b/RoonController/RoonController.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bertrand.RoonController;
 				PRODUCT_NAME = "Roon Controller";
 				SDKROOT = macosx;
@@ -581,7 +581,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.bertrand.RoonController;
 				PRODUCT_NAME = "Roon Controller";
 				SDKROOT = macosx;

--- a/RoonController/Services/Roon/Core/RoonRegistration.swift
+++ b/RoonController/Services/Roon/Core/RoonRegistration.swift
@@ -13,7 +13,7 @@ struct RoonRegistration {
 
     static let extensionId = "com.bertrand.rooncontroller"
     static let displayName = "Roon Controller macOS"
-    static let displayVersion = "1.1.0"
+    static let displayVersion = "1.1.1"
     static let publisher = "Bertrand"
     static let email = ""
 

--- a/RoonController/Tests/RoonServiceTests.swift
+++ b/RoonController/Tests/RoonServiceTests.swift
@@ -1282,7 +1282,7 @@ final class RoonServiceTests: XCTestCase {
     }
 
     func testRegistrationDisplayVersion() {
-        XCTAssertEqual(RoonRegistration.displayVersion, "1.1.0")
+        XCTAssertEqual(RoonRegistration.displayVersion, "1.1.1")
     }
 
     func testRegistrationExtensionId() {
@@ -1679,7 +1679,7 @@ final class RoonServiceTests: XCTestCase {
 
     func testVersionNumberMatchesRelease() {
         // Fix: version number was stuck at 1.0.3
-        XCTAssertEqual(RoonRegistration.displayVersion, "1.1.0",
+        XCTAssertEqual(RoonRegistration.displayVersion, "1.1.1",
                        "displayVersion must match the current release")
     }
 


### PR DESCRIPTION
## Summary

- **Version number** updated to 1.1.0 then 1.1.1
- **Volume repeat speed** 200ms → 100ms for snappier response
- **Settings gear** in Player mode toolbar (Cmd+,)
- **Recently played** albums navigate to detail instead of playing
- **Mouse back button** support for browse navigation
- **Seek sync** prioritize server updates over local timer interpolation
- **Layout detection** multilingual Tracks/Composers/Album column (10 languages)
- **Volume 0–100 scale** option + startup view setting
- **Profile switching** fix using title matching instead of stale session keys
- **"More" button** fix: clear browse dedup guard after response
- **Window resize** responsive transport bar + dynamic player art scaling
- **Radio Favorites** renamed and separated from future Roon favorites
- **Roon library heart toggle** via Browse API for all tracks (not just radio)

## Tests

326 tests, 0 failures

## Test plan

- [ ] Build Release DMG
- [ ] Install on clean macOS, verify `xattr -cr` workflow
- [ ] Connect to Roon Core, verify all zones visible
- [ ] Player mode: volume slider, heart toggle, settings gear
- [ ] Roon mode: browse, back button, More actions, resize window
- [ ] Radio: heart saves to Radio Favorites section
- [ ] Non-radio: heart toggles Roon library status

🤖 Generated with [Claude Code](https://claude.com/claude-code)